### PR TITLE
Add Karambolo.Extensions.Logging.File to Logging category

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@ Check out my [blog](https://medium.com/@thangchung) or say hi on [Twitter](https
 * [dnxcore-logging-logstash](https://github.com/jvandevelde/dnxcore-logging-logstash) - Logstash logging extension for .NET Core applications with UDP and Redis transports.
 * [Exceptionless](https://github.com/exceptionless/Exceptionless.Net) - Exceptionless .NET Client
 * [Foundatio](https://github.com/exceptionless/Foundatio#logging) - A fluent logging api that can be used to log messages throughout your application.
+* [Karambolo.Extensions.Logging.File](https://github.com/adams85/filelogger) - A lightweight library which implements file logging for the built-in .NET Core logging framework (Microsoft.Extensions.Logging).
 * [LibLog](https://github.com/damianh/LibLog) - Single file for you to either copy/paste or install via nuget, into your library/ framework/ application to provide a logging abstraction.
 * [log4net](https://github.com/apache/logging-log4net) - log4net is a port of the excellent Apache log4j™ framework to the Microsoft® .NET runtime.
 * [NLog](https://github.com/NLog/NLog) - Advanced .NET, Silverlight and Xamarin Logging.


### PR DESCRIPTION
.NET Core (up to v2.x) doesn't include a Microsoft.Extensions.Logging.ILoggerProvider implementation for file logging. This library was written to fill in this gap.

The code is based on ConsoleLogger whose full feature set is implemented (including log scopes and configuration reloading). The library is lightweight, has no 3rd party dependencies. No I/O blocking occurs as processing of log messages is done in the background. File system access is implemented on top of the Microsoft.Extensions.FileProviders.IFileProvider abstraction so it's even possible to use a custom backing storage.

It's an ideal solution for .NET Core projects which don't need the advanced features of the feature-rich, heavyweight logging frameworks.

For more details, please visit:
https://github.com/adams85/filelogger
